### PR TITLE
Add Map and Set serialization

### DIFF
--- a/assembly/__tests__/runtime/roundtrip.spec.ts
+++ b/assembly/__tests__/runtime/roundtrip.spec.ts
@@ -80,8 +80,27 @@ describe("Round Trip", () => {
       arr.pushFront("hello");
       expect<PersistentDeque<string>>(roundtrip(arr)).toStrictEqual(arr);
     });
-  }); 
-})
+  });
+
+  describe("Maps", () => {
+    beforeEach(() =>{
+      map = new Map<string, string>();
+    });
+
+    it("should handle an empty map", () => {
+      expect(roundtrip(map)).toStrictEqual(map);
+    });
+
+    it("should handle entries", () => {
+      map.set("hello", "world");
+      expect(roundtrip(map)).toStrictEqual(map);
+      map.set("world", "hello");
+      expect(roundtrip(map)).toStrictEqual(map);
+    });
+  });
+});
+
+let map: Map<string, string>;
 
 class Generic<T> {
   constructor(public value: T){}
@@ -91,8 +110,6 @@ class Foo{}
 export const Foo_ID = idof<Foo>();
 export const Generic_i32_ID = idof<Generic<i32>>();
 export const Generic_Foo_ID = idof<Generic<Foo>>();
-
-
 
 
 

--- a/assembly/__tests__/runtime/roundtrip.spec.ts
+++ b/assembly/__tests__/runtime/roundtrip.spec.ts
@@ -82,7 +82,7 @@ describe("Round Trip", () => {
     });
   });
 
-  describe("Maps", () => {
+  describe("Map", () => {
     beforeEach(() =>{
       map = new Map<string, string>();
     });
@@ -98,9 +98,26 @@ describe("Round Trip", () => {
       expect(roundtrip(map)).toStrictEqual(map);
     });
   });
+  describe("Set", () => {
+    beforeEach(() =>{
+      aSet = new Set<string>();
+    });
+
+    it("should handle an empty set", () => {
+      expect(roundtrip(aSet.values())).toStrictEqual([]);
+    });
+
+    it("should handle entries", () => {
+      aSet.add("hello");
+      expect(roundtrip(aSet).values()).toStrictEqual(aSet.values());
+      aSet.add("world");
+      expect(roundtrip(aSet).values()).toStrictEqual(aSet.values());
+    });
+  });
 });
 
 let map: Map<string, string>;
+let aSet: Set<string>;
 
 class Generic<T> {
   constructor(public value: T){}

--- a/assembly/as_types.d.ts
+++ b/assembly/as_types.d.ts
@@ -9,7 +9,7 @@ declare interface Array<T> {
 }
 
 declare function decode<T, K = Uint8Array>(buffer: K, name?: string): T;
-declare function encode<T, K = Uint8Array>(item: T, name?: string): K;
+declare function encode<T, K = Uint8Array>(item: T, name?: string, encoder?: any): K;
 
 declare interface Object {
   encode(): Uint8Array;

--- a/assembly/bindgen.ts
+++ b/assembly/bindgen.ts
@@ -120,10 +120,17 @@ function encode<T, Output = Uint8Array>(value: T, name: string | null = "", enco
             encode<valueof<T>, JSONEncoder>(value.get(keys[i]), keys[i], encoder);
           }
           encoder.popObject();
+        } else if (value instanceof Set) {
+          // @ts-ignore
+          let values: Array<indexof<T>> = value.values();
+          encoder.pushArray(name);
+          for (let i = 0; i < values.length; i++) {
+            //@ts-ignore
+            encode<indexof<T>, JSONEncoder>(values[i], null, encoder);
+          }
+          encoder.popArray();
         }
      }
-     
-
     }
   } else {
     throw new Error("Encoding failed " + (name != null && name != "" ? (" for " + name) : "") + " with type " + nameof<T>());
@@ -158,14 +165,26 @@ function decodeArray<T>(val: JSON.Value, name: string): Array<T> {
   return res;
 }
 
-function decodeMap<V>(val: JSON.Obj, name: string): Map<string, V> {
-  assert(val instanceof JSON.Obj, "Value with Key: " + name + " is not an Obj.");
+function decodeMap<V>(aVal: JSON.Value, name: string): Map<string, V> {
+  assert(aVal instanceof JSON.Obj, "Value with Key: " + name + " is not an Obj.");
+  let val = <JSON.Obj>aVal;
   let map = new Map<string, V>();
   for (let i = 0; i < val.keys.length; i++) {
     let key = val.keys[i];
     map.set(key, decode<V, JSON.Value>(<JSON.Value>val.get(key)));
   }
   return map;
+}
+
+function decodeSet<V>(aVal: JSON.Value, name: string): Set<V> {
+  assert(aVal instanceof JSON.Arr, "Value with Key: " + name + " is not an Obj.");
+  let arr = (<JSON.Arr> aVal)._arr;
+  let set = new Set<V>();
+  for (let i = 0; i < arr.length; i++) {
+    let val = arr[i];
+    set.add(decode<V, JSON.Value>(val));
+  }
+  return set;
 }
 
 function isReallyNullable<T>(): bool {
@@ -260,6 +279,12 @@ function decode<T, V = Uint8Array>(buf: V, name: string = ""): T {
     assert(nameof<indexof<T>>() == "String", "Value with Key: " + name + " cannot decode a map which has an index type "+ nameof<indexof<T>>() + ", it must be a string");
     //@ts-ignore
     return <T>decodeMap<valueof<T>>(<JSON.Obj>val, name);
+  }
+  //@ts-ignore
+  if (value instanceof Set) {
+    assert(val instanceof JSON.Arr, "Value with Key: " + name + " of type map expected a JSON.Obj, but recevied " + JSONTypeToString(val));
+    //@ts-ignore
+    return <T>decodeSet<indexof<T>>(val, name);
   }
   if (isArrayLike<T>()) {
     //@ts-ignore


### PR DESCRIPTION
Fixes #99 

One restriction for maps is that the keys are strings.  This could be lifted in the future, but requires more thought.