### PR TITLE
Fix asc to v0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@as-pect/cli": "^3.2.6",
     "as-bignum": "^0.1.5",
-    "assemblyscript": "^0.10.0",
+    "assemblyscript": "0.10.0",
     "assemblyscript-json": "^0.3.1",
     "bn.js": "^5.1.1",
     "bs58": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -780,7 +780,7 @@ assemblyscript-json@^0.3.1:
   resolved "https://registry.yarnpkg.com/assemblyscript-json/-/assemblyscript-json-0.3.1.tgz#bd6053eba21cd29bef2fee5c8dfc6392401c97cf"
   integrity sha512-RScAzu/PUejojfXgZnAfy9FUkePSh/zIs3eAaFPWpiBQjS8eWc8aOdM2Q68TI6D7AybyJAK8G3iVF7Qd2Uakcw==
 
-assemblyscript@^0.10.0:
+assemblyscript@0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/assemblyscript/-/assemblyscript-0.10.0.tgz#0d2a0591be77fdd294d720172e307e526a559ba8"
   integrity sha512-ErUNhHboD+zsB4oG6X1YICDAIo27Gq7LeNX6jVe+Q0W5cI51/fHwC8yJ68IukqvupmZgYPdp1JqqRXlS+BrUfA==


### PR DESCRIPTION
currently 0.10.1 breaks the AST API so this will ensure end users don't update to that version.
