### PR TITLE
Allow getPrimitives to use string

### DIFF
--- a/assembly/__tests__/bindgen/badType.ts
+++ b/assembly/__tests__/bindgen/badType.ts
@@ -1,0 +1,3 @@
+import { storage } from "../..";
+class Foo {}
+storage.getPrimitive<Foo>("hello", new Foo());

--- a/assembly/bindgen.ts
+++ b/assembly/bindgen.ts
@@ -106,6 +106,7 @@ function encode<T, Output = Uint8Array>(value: T, name: string | null = "", enco
               encoder.setNull(name);
           }
         } else {
+          //@ts-ignore
           value._encode(name, encoder);
         }
        } else if (isArrayLike<T>(value)) {

--- a/assembly/runtime/logging.ts
+++ b/assembly/runtime/logging.ts
@@ -3,7 +3,8 @@ import { util } from "./util";
 
 export namespace logging {
   /**
-   * Log a string message.
+   * Log a string message. If T has `toString` it is called, 
+   * otherwise T must be serializable.
    *
    * Logs are stored as an array of strings
    *
@@ -15,7 +16,8 @@ export namespace logging {
    */
   export function log<T = string>(msg: T): void {
     let msg_encoded: Uint8Array;
-    if (isString<T>()) {
+    //@ts-ignore
+    if (isString<T>() || isDefined(msg.toString)) {
       //@ts-ignore
       let message = msg.toString();
       msg_encoded= util.stringToBytes(message);

--- a/assembly/runtime/storage.ts
+++ b/assembly/runtime/storage.ts
@@ -191,12 +191,11 @@ export class Storage {
    * @returns A value of type T stored under the given key.
    */
   getPrimitive<T>(key: string, defaultValue: T): T {
-    if (isInteger<T>()) {
-      const strValue = this.getString(key);
-      return strValue == null ? defaultValue : util.parseFromString<T>(<string>strValue);
-    } else {
-      throw "Operation not supported. Please use storage.get<T> for non-primitives";
-    }
+    if (!isInteger<T>() && !isString<T>()) {
+      ERROR("Operation not supported. Please use storage.get<T> for non-primitives");
+    } 
+    const strValue = this.getString(key);
+    return strValue == null ? defaultValue : util.parseFromString<T>(<string>strValue);
   }
 
   /**

--- a/bindgen/asconfig.js
+++ b/bindgen/asconfig.js
@@ -26,5 +26,7 @@ function buildFail(msg, input, output, args, options) {
 buildFail("Missing input file should fail")
 buildFail("Missing output file should fail.", "../assembly/__tests__/bindgen/bad.ts")
 buildFail("Failing to compiling should fail.", "../assembly/__tests__/bindgen/bad.ts", "out/bad.wasm", [], { verbose:true })
+buildFail("Failing to types compiling should fail.", "../assembly/__tests__/bindgen/badType.ts", "out/badType.wasm", [], { verbose:true })
+
 console.log("PASSED");
 


### PR DESCRIPTION
Also make use of ERROR so that use of wrong types cause compile time error
