### PR TITLE
chore: update near vm

### DIFF
--- a/assembly/as_types.d.ts
+++ b/assembly/as_types.d.ts
@@ -35,3 +35,8 @@ declare function defaultValue<T>(): T;
  * Throw if attached deposit.
  */
 declare function notPayable(): void;
+
+/**
+ * Produces a warning during transform that element is deprecated.
+ */
+declare function deprecated(_any: any): void;

--- a/assembly/sdk/contract.ts
+++ b/assembly/sdk/contract.ts
@@ -363,7 +363,4 @@ export class ContractPromiseResult {
   ) {}
 }
 
-// @ts-ignore
-// prettier-ignore
-@deprecated
 export { Context as context };

--- a/assembly/sdk/contract.ts
+++ b/assembly/sdk/contract.ts
@@ -363,4 +363,7 @@ export class ContractPromiseResult {
   ) {}
 }
 
+// @ts-ignore
+// prettier-ignore
+@deprecated
 export { Context as context };

--- a/assembly/sdk/contract.ts
+++ b/assembly/sdk/contract.ts
@@ -362,3 +362,5 @@ export class ContractPromiseResult {
     public buffer: Uint8Array = defaultValue<Uint8Array>()
   ) {}
 }
+
+export { Context as context };

--- a/assembly/sdk/storage.ts
+++ b/assembly/sdk/storage.ts
@@ -256,7 +256,4 @@ export class Storage {
   }
 }
 
-// @ts-ignore
-// prettier-ignore
-@deprecation
-export { Storage as storage }
+export { Storage as storage };

--- a/assembly/sdk/storage.ts
+++ b/assembly/sdk/storage.ts
@@ -6,7 +6,7 @@ import { util } from "./util";
  *
  * It is a key-value store that is persisted on the NEAR blockchain.
  */
-export class storage {
+export class Storage {
   /**
    * Store string value under given key. Both key and value are encoded as UTF-8 strings.
    *
@@ -255,3 +255,8 @@ export class storage {
     }
   }
 }
+
+// @ts-ignore
+// prettier-ignore
+@deprecation
+export { Storage as storage }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bs58": "^4.0.1",
     "js-base64": "^3.4.3",
     "near-mock-vm": "^0.1.1",
-    "near-vm": "^0.0.8",
+    "near-vm": "^1.1.0",
     "visitor-as": "^0.2.0"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2472,7 +2472,7 @@ jest-snapshot@^26.2.2:
     pretty-format "^26.2.0"
     semver "^7.3.2"
 
-jest-util@^26.2.0:
+jest-util@26.x, jest-util@^26.2.0:
   version "26.2.0"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-26.2.0.tgz#0597d2a27c559340957609f106c408c17c1d88ac"
   integrity sha512-YmDwJxLZ1kFxpxPfhSJ0rIkiZOM0PQbRcfH0TzJOhqCisCAsI1WcmoQqO83My9xeVA2k4n+rzg2UuexVKzPpig==
@@ -2904,10 +2904,10 @@ near-mock-vm@^0.1.1:
     js-base64 "^2.5.2"
     yargs "^15.3.1"
 
-near-vm@^0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/near-vm/-/near-vm-0.0.8.tgz#9b1cec1fd875886fcbf45333744f81e0f288d795"
-  integrity sha512-w20MTgQ+EZi92qi5hkPTBVVS0+macU4ZqlxIZ/n+W+me2WLl7jg/7OMM1Vg7bpA+V2m9R+BIOchFBTCDrij8Aw==
+near-vm@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/near-vm/-/near-vm-1.1.0.tgz#3166bdef13e7071829d2f5621b16ddfe298e011c"
+  integrity sha512-7L8pmtoBJXJ5+ETdXKuFM8E9tvOd5r3IXAxF4khhg73/HC58fCTQVUZKxfF4P6tXx2j3V+gFMnioOgbr2KrpnA==
   dependencies:
     binary-install "^0.0.1"
 


### PR DESCRIPTION
Also adds back `context` so that projects won't break when upgrading.  Will soon add a deprecation warning to it.