### PR TITLE
Export safe as-bignum types by default

### DIFF
--- a/sdk-core/assembly/index.ts
+++ b/sdk-core/assembly/index.ts
@@ -8,4 +8,6 @@ export * from "./base58";
 export * from "./logging";
 export * from "./math";
 export * from "./promise";
-export * from "as-bignum";
+
+export * from "as-bignum/integer/safe/u128";
+export * from "as-bignum/integer/safe/u256";

--- a/sdk-core/package.json
+++ b/sdk-core/package.json
@@ -12,7 +12,7 @@
   "license": "(MIT AND Apache-2.0)",
   "dependencies": {
     "@as-pect/cli": "^5.0.0",
-    "as-bignum": "^0.2.8",
+    "as-bignum": "^0.2.10",
     "asbuild": "^0.0.10",
     "assemblyscript": "^0.17.3",
     "assemblyscript-json": "^0.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1920,10 +1920,10 @@ arrify@^1.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
 
-as-bignum@^0.2.8:
-  version "0.2.8"
-  resolved "https://registry.yarnpkg.com/as-bignum/-/as-bignum-0.2.8.tgz#46ac7a14cf9df951aa3fb850f1db44c0083d4e69"
-  integrity sha512-tac9YOYKDLlkiVFiucTsHRIEzd+LawAHfmxqucnfZmZ6TH4DGMzMBw5A6Zex0YWGNLaLHtPz/5z8nA5yyXryNg==
+as-bignum@^0.2.10:
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/as-bignum/-/as-bignum-0.2.10.tgz#cba10a318d2eb731709220db47455fb430c4621d"
+  integrity sha512-uTB/06+xoAQSzVlF/8CQHhbIrdEet6oqjIrZ7RemWGeIDdjwHOyra9cyjedmf0UpcyHp0kY82zKab0fLNTxcvQ==
 
 asap@^2.0.0:
   version "2.0.6"


### PR DESCRIPTION
This makes it easier for contract developer to avoid integer overflow / underflow errors.

These were independently hit by both me in Bananaswap and Paras.