### PR TITLE
fix: remove @inline decorator on static reference

### DIFF
--- a/sdk-core/assembly/storage.ts
+++ b/sdk-core/assembly/storage.ts
@@ -114,7 +114,6 @@ export class Storage {
    * @param key The unique identifier associated with a value in a key-value store
    * @returns True if the given key is present in the storage.
    */
-  @inline
   static hasKey(key: string): bool {
     return this.contains(key);
   }

--- a/simulator/assembly/__tests__/singleton.ts
+++ b/simulator/assembly/__tests__/singleton.ts
@@ -1,4 +1,4 @@
-import { logging, PersistentSet, Context, persist } from "near-sdk-as";
+import { storage, logging, PersistentSet, Context, persist } from "near-sdk-as";
 
 
 @nearBindgen
@@ -39,6 +39,11 @@ export class Singleton {
 
   lastVisited(): string {
     return this.last_visited || "";
+  }
+
+  // test to make sure we don't get compiler error
+  storageCheck(): void {
+    storage.hasKey('key')
   }
 
   private hasNotVisited(visitor: string): boolean {

--- a/simulator/assembly/__tests__/singleton.ts
+++ b/simulator/assembly/__tests__/singleton.ts
@@ -43,7 +43,7 @@ export class Singleton {
 
   // test to make sure we don't get compiler error
   storageCheck(): void {
-    storage.hasKey('key')
+    storage.hasKey('key');
   }
 
   private hasNotVisited(visitor: string): boolean {


### PR DESCRIPTION
`@inline` decorator on static reference  to`this` keyword was causing compile to fail