### PR TITLE
feat: Add CachingStorage

### DIFF
--- a/sdk-core/assembly/collections/collection.ts
+++ b/sdk-core/assembly/collections/collection.ts
@@ -1,0 +1,32 @@
+import { collections } from ".";
+import { Storage } from "..";
+
+/**
+ * Top level Collection class.
+ */
+export abstract class Collection {
+
+  
+  constructor(protected storage: Storage = Storage.cachingStorage) {}
+
+
+
+}
+
+export abstract class PrefixedCollection<K> extends Collection {
+  get _elementPrefix(): string {
+    return this.prefix + collections._KEY_ELEMENT_SUFFIX;
+  }
+
+  constructor(protected prefix: string, storage: Storage = Storage.cachingStorage){
+    super(storage);
+  }
+
+  /**
+   * @returns An internal string key for a given key of type K.
+   */
+  protected _key(key: K): string {
+    // @ts-ignore: TODO: Add interface that forces all K types to have toString
+    return this._elementPrefix + key.toString();
+  }
+}

--- a/sdk-core/assembly/collections/index.ts
+++ b/sdk-core/assembly/collections/index.ts
@@ -44,6 +44,8 @@ export namespace collections {
 }
 
 /** @internal */
+export * from "./collection";
+/** @internal */
 export * from "./persistentDeque";
 /** @internal */
 export * from "./persistentMap";

--- a/sdk-core/assembly/collections/maxHeap.ts
+++ b/sdk-core/assembly/collections/maxHeap.ts
@@ -1,4 +1,4 @@
-import { PersistentVector } from "./persistentVector";
+import { PersistentVector } from ".";
 
 /**
  * A max heap. Maintains a tree structure on an underlying vector. Storage cost Θ(n)

--- a/sdk-core/assembly/collections/persistentMap.ts
+++ b/sdk-core/assembly/collections/persistentMap.ts
@@ -1,5 +1,4 @@
-import { collections } from ".";
-import { storage } from "../storage";
+import { PrefixedCollection } from "./collection";
 
 /**
  * This class is one of several convenience collections built on top of the `Storage` class
@@ -29,8 +28,7 @@ import { storage } from "../storage";
  * @typeParam V The generic type parameter `V` can be any [valid AssemblyScript type](https://docs.assemblyscript.org/basics/types).
  */
 @nearBindgen
-export class PersistentMap<K, V> {
-  private _elementPrefix: string;
+export class PersistentMap<K, V> extends PrefixedCollection<K> {
 
   /**
    * Creates or restores a persistent map with a given storage prefix.
@@ -45,15 +43,7 @@ export class PersistentMap<K, V> {
    * @param prefix A prefix to use for every key of this map.
    */
   constructor(prefix: string) {
-    this._elementPrefix = prefix + collections._KEY_ELEMENT_SUFFIX;
-  }
-
-  /**
-   * @returns An internal string key for a given key of type K.
-   */
-  private _key(key: K): string {
-    // @ts-ignore: TODO: Add interface that forces all K types to have toString
-    return this._elementPrefix + key.toString();
+    super(prefix);
   }
 
   /**
@@ -71,7 +61,7 @@ export class PersistentMap<K, V> {
    * @returns True if the given key present in the map.
    */
   contains(key: K): bool {
-    return storage.contains(this._key(key));
+    return this.storage.contains(this._key(key));
   }
 
   /**
@@ -88,7 +78,7 @@ export class PersistentMap<K, V> {
    * @param key Key to remove.
    */
   delete(key: K): void {
-    storage.delete(this._key(key));
+    this.storage.delete(this._key(key));
   }
 
   /**
@@ -110,7 +100,7 @@ export class PersistentMap<K, V> {
    * @returns Value for the given key or the default value.
    */
   get(key: K, defaultValue: V | null = null): V | null {
-    return storage.get<V>(this._key(key), defaultValue);
+    return this.storage.get<V>(this._key(key), defaultValue);
   }
 
   /**
@@ -130,7 +120,7 @@ export class PersistentMap<K, V> {
    * @returns Value for the given key or the default value.
    */
   getSome(key: K): V {
-    return storage.getSome<V>(this._key(key));
+    return this.storage.getSome<V>(this._key(key));
   }
 
   /**
@@ -145,6 +135,6 @@ export class PersistentMap<K, V> {
    * @param value The new value of the element.
    */
   set(key: K, value: V): void {
-    storage.set<V>(this._key(key), value);
+    this.storage.set<V>(this._key(key), value);
   }
 }

--- a/sdk-core/assembly/collections/persistentSet.ts
+++ b/sdk-core/assembly/collections/persistentSet.ts
@@ -1,6 +1,8 @@
 import { PersistentMap } from "./persistentMap";
 import { PersistentVector } from "./persistentVector";
 import { math } from "../math";
+import { Collection } from "./collection";
+import { Storage } from '../storage';
 
 /**
  * A vector class that implements a persistent array.
@@ -23,7 +25,7 @@ import { math } from "../math";
  *
  */
 @nearBindgen
-export class PersistentSet<T> {
+export class PersistentSet<T> extends Collection {
   private _map: PersistentMap<Uint8Array, i32>;
   private _vector: PersistentVector<T>;
 
@@ -32,7 +34,8 @@ export class PersistentSet<T> {
    * Always use a unique storage prefix for different collections.
    * @param prefix A prefix to use for every key of this set.
    */
-  constructor(prefix: string) {
+  constructor(prefix: string, storage: Storage = Storage.cachingStorage ) {
+    super(storage);
     this._map = new PersistentMap<Uint8Array, i32>("_map" + prefix);
     this._vector = new PersistentVector<T>("_vector" + prefix);
   }

--- a/sdk-core/assembly/collections/persistentUnorderedMap.ts
+++ b/sdk-core/assembly/collections/persistentUnorderedMap.ts
@@ -1,8 +1,10 @@
+import { Storage } from "..";
+import { Collection } from "./collection";
 import { PersistentMap } from "./persistentMap";
 import { PersistentVector } from "./persistentVector";
 import { MapEntry } from "./util";
 
-export class PersistentUnorderedMap<K, V> {
+export class PersistentUnorderedMap<K, V> extends Collection {
   private _map: PersistentMap<K, i32>;
   private _entries: PersistentVector<MapEntry<K, V>>;
 
@@ -18,7 +20,8 @@ export class PersistentUnorderedMap<K, V> {
    *
    * @param prefix A prefix to use for every key of this map.
    */
-  constructor(prefix: string) {
+  constructor(prefix: string, storage: Storage = Storage.cachingStorage) {
+    super(storage);
     this._map = new PersistentMap<K, i32>(prefix + ":map"); // stores key=>index
     this._entries = new PersistentVector<MapEntry<K, V>>(prefix + ":entries"); // stores vec[index]=<key,value>
   }

--- a/sdk-core/assembly/index.ts
+++ b/sdk-core/assembly/index.ts
@@ -11,3 +11,9 @@ export * from "./promise";
 export * from "./datetime";
 
 export { u128, u256 } from "./bignum";
+
+import { Storage } from "./storage";
+
+// @ts-ignore
+@lazy
+export const storage = Storage.cachingStorage;

--- a/sdk-core/assembly/math.ts
+++ b/sdk-core/assembly/math.ts
@@ -1,6 +1,6 @@
 import { env } from "./env";
 import { util } from "./util";
-import { storage } from "./storage";
+import { storage } from ".";
 
 export namespace math {
   /**

--- a/sdk-core/assembly/util.ts
+++ b/sdk-core/assembly/util.ts
@@ -124,6 +124,12 @@ export function persist<T>(state: T): void {
 
 // @ts-ignore
 @inline
+export function isNumber<T>(): boolean { 
+  return isInteger<T>() || isFloat<T>();
+}
+
+// @ts-ignore
+@inline
 export function isPrimitive<T>(): boolean {
-  return isInteger<T>() || isFloat<T>() || isString<T>();
+  return isNumber<T>() || isString<T>();
 }

--- a/sdk/assembly/__tests__/storage.spec.ts
+++ b/sdk/assembly/__tests__/storage.spec.ts
@@ -1,0 +1,28 @@
+import { Storage, Context } from "..";
+
+const key = "KEY";
+const value = "VALUE";
+
+
+function loadNTimes(n: i32, s: Storage): void {
+  log(`host gas before ${Context.usedGas}`);
+  for (let i = 0; i < n; i++) {
+    s.getSome<string>(key);
+  }
+  log(`host gas after ${n} reads ${Context.usedGas}`);
+}
+
+let numberOfTests = 10;
+
+describe("Test difference between storages", () => {
+
+  beforeEach(() => {
+    Storage.cachingStorage.set(key, value);
+  });
+
+  it("test differences in loop of reads", () => {    
+    loadNTimes(numberOfTests, Storage.storage);
+    loadNTimes(numberOfTests, Storage.cachingStorage);
+  });
+
+});

--- a/sdk/assembly/__tests__/test_storage.ts
+++ b/sdk/assembly/__tests__/test_storage.ts
@@ -1,0 +1,21 @@
+import { Storage, Context, logging } from "..";
+
+const key = "KEY";
+const value = "VALUE";
+
+
+function loadNTimes(n: i32, s: Storage): void {
+  const before = Context.usedGas;
+  for (let i = 0; i < n; i++) {
+    if (i % 2)
+      s.getSome<string>(key);
+  }
+  logging.log(`host gas used after ${n} reads ${Context.usedGas - before}`);
+}
+
+Storage.cachingStorage.set(key, value);
+
+export function runTest(i: i32): void {
+  loadNTimes(i, Storage.storage);
+  loadNTimes(i, Storage.cachingStorage);
+}


### PR DESCRIPTION
`Storage` is now the base class and `CachingStorage, intercepts calls and uses a local cache. Lazy static members are used to ensure a single of both `storage: Storage` and `cachingStorage: CachingStorage`.

Also the structure of collections is now hierarchical with a `Collection` class at the top and a `PrefixedCollection` for those that need to access their prefix, while others are made up of other collections.  The collection this has a reference to storage with defaults to `Storage.cachingStorage`.