### PR TITLE
fix: overload get method definition (help needed)

### DIFF
--- a/sdk-core/assembly/collections/persistentMap.ts
+++ b/sdk-core/assembly/collections/persistentMap.ts
@@ -110,7 +110,10 @@ export class PersistentMap<K, V> {
    * @returns Value for the given key or the default value.
    */
   get(key: K, defaultValue: V | null = null): V | null {
-    return storage.get<V>(this._key(key), defaultValue);
+    if (defaultValue) {
+      return storage.get<V>(this._key(key), defaultValue);
+    }
+    return storage.get<V>(this._key(key));
   }
 
   /**

--- a/sdk-core/assembly/storage.ts
+++ b/sdk-core/assembly/storage.ts
@@ -177,6 +177,8 @@ export class Storage {
    * @param defaultValue The default value if the key is not available
    * @returns A value of type T stored under the given key.
    */
+  static get<T>(key: string): T | null;
+  static get<T>(key: string, defaultValue: T): T;
   static get<T>(key: string, defaultValue: T | null = null): T | null {
     if (isString<T>()) {
       const strValue = this.getString(key);


### PR DESCRIPTION
The current `get` method in both storage and persist map has return type `V | null`.
However, if a defaultValue of type V is passed, it won't return null.

I tried to fix the declaration of `get` method with function overloading but get an error when compiling:      
`ERROR TS2391: Function implementation is missing or not immediately following the declaration.`
But similar code can compile if using plain typescript.

Doesn't assembly script support function overloading or I did it wrong?