### PR TITLE
Update Readme with FAQ / Troubleshooting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ will create a debug build and place it in `./build/debug/..`
 
 See the [sdk's as-pect tests for an example](./sdk/assembly/__tests__) of creating unit tests.  Must be ending in `.spec.ts` in a `assembly/__tests__`.
 
+## FAQ / Troubleshooting
+
+* Floating point arithmetics are not supported in NEAR smart contracts.
+
 ## License
 
 `near-sdk-as` is distributed under the terms of both the MIT license and the Apache License (Version 2.0).


### PR DESCRIPTION
## Bakground
The reason for this PR is that i created a [issue](https://github.com/MaxGraey/as-bignum/issues/70) for the `as-bignum` module, where i got the clarification that floating points are not support in NEAR contracts.

But searching both in the Github README file and docs for [near-sdk-as](https://near.github.io/near-sdk-as/), I can't find any information that floating points arithmetics are not supported in NEAR smart contracts and should not be used.

I did a Github Search where i can see it mentioned in two files:

![Screenshot 2021-12-02 at 22 48 17](https://user-images.githubusercontent.com/155505/144508544-61aba87e-2d05-4a59-8766-87e1310d7066.png)

There is also typechecker hook for [`Bindgen`](https://github.com/near/near-sdk-as/blob/48e5f359d07db891977e188715c3afec028aaf16/bindgen/src/typeChecker.ts#L67-L76) that will check this, but when trying to use floating points otherwise there is no warning about this when compiling 🤷🏽 .

## Solution

Quick proposal and solution is to update Readme with FAQ / Troubleshooting section, that informs users that Floating point arithmetics are not supported in NEAR smart contracts.