### PR TITLE
fix: bug when storing `string | null` values

### DIFF
--- a/bindgen/assembly/__tests__/model.ts
+++ b/bindgen/assembly/__tests__/model.ts
@@ -31,6 +31,14 @@ export class Nullables {
 }
 
 @nearBindgen
+export class OrNullables {
+  str: string | null;
+  u128: u128 | null;
+  // TODO: Fix uint8Array or null
+  // uint8Array: Uint8Array | null;
+}
+
+@nearBindgen
 export class ContainerClass {
   foobar: FooBar;
 }

--- a/bindgen/assembly/__tests__/test.ts
+++ b/bindgen/assembly/__tests__/test.ts
@@ -3,6 +3,7 @@ import { base64, logging, u128 } from "near-sdk-as";
 import {
   FooBar,
   Nullables,
+  OrNullables,
   ContainerClass,
   AnotherContainerClass,
 } from "./model";
@@ -63,6 +64,9 @@ export function runTest(): void {
 
   const nullable = new Nullables();
   logging.log(String.UTF8.decode(nullable.encode().buffer));
+  const ornullable = new OrNullables();
+  logging.log(String.UTF8.decode(ornullable.encode().buffer));
+
   // @ts-ignore
   const nullable2 = decode<Nullables>(nullable.encode());
   assert(nullable2.str == null);

--- a/bindgen/assembly/index.ts
+++ b/bindgen/assembly/index.ts
@@ -122,7 +122,7 @@ function encode<T, Output = Uint8Array>(
       encoder.setNull(name);
     } else {
       // @ts-ignore
-      encoder.setString(name, value);
+      encoder.setString(name, value as string);
     }
   } else if (isReference<T>()) {
     // @ts-ignore


### PR DESCRIPTION
Error:
~~~
ERROR TS2322: Type '~lib/string/String | null' is not assignable to type '~lib/string/String'.
       encoder.setString(name, value);
                               ~~~~~
 in ~lib/near-sdk-bindgen/index.ts(125,31)
~~~

Notes: 
The cast is safe due to the null check before it.