### PR TITLE
Adding a new panic method that display custom Error

### DIFF
--- a/sdk-core/assembly/env/env.ts
+++ b/sdk-core/assembly/env/env.ts
@@ -102,6 +102,9 @@ export namespace env {
   @external("env", "panic_utf8")
   export declare function panic_utf8(len: u64, ptr: u64): void;
   // @ts-ignore
+  @external("env", "panic_str")
+  export declare function panic_str(msg: string): void;
+  // @ts-ignore
   @external("env", "log_utf8")
   export declare function log_utf8(len: u64, ptr: u64): void;
   // @ts-ignore


### PR DESCRIPTION
There is no official or legit way to create panic when certain criteria are not matched in the near assembly runtime library. Throwing a new Error `throw new Error("...")` doesn't help to debug the code. So we can add a custom panic error method that can be invoked with a custom message...
`
function panic_str(msg: string): void {
   env.panic_utf8(msg.length, changetype<usize>(String.UTF8.encode(msg, false)))
}