### PR TITLE
Add @as-pect/cli as dev dependency to near-sdk-as

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -24,6 +24,7 @@
     "build": "asb assembly/__tests__/main.ts -- --noEmit"
   },
   "devDependencies": {
+    "@as-pect/cli": "^6.2.4",
     "@assemblyscript/loader": "^0.18.9",
     "@types/bn.js": "^5.1.0",
     "@types/bs58": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,45 @@
 # yarn lockfile v1
 
 
+"@as-covers/assembly@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@as-covers/assembly/-/assembly-0.2.0.tgz#6f335834483ddf91b21da06955bd86647f9e8db9"
+  integrity sha512-3Mo0pdLmaorJPqookq10LmJlWIpyXF/D9JWjphMtv5Th23yO537t6vMGi92uKe35d07k2xMOH/4WRHi04mlk6Q==
+
+"@as-covers/core@0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@as-covers/core/-/core-0.2.1.tgz#362a4719a1901d416941f5425b63fa46288ce8e6"
+  integrity sha512-/GGTzPB850shvL6ZiidKDmIXSpBflYfzhYyipe7HA1eijBQKKluaLSRy/JLSN53f6kp3tLrCevPXN6HA2fyuBw==
+  dependencies:
+    "@as-covers/assembly" "^0.2.0"
+    "@as-covers/glue" "^0.2.0"
+    "@as-covers/transform" "^0.2.1"
+
+"@as-covers/glue@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@as-covers/glue/-/glue-0.2.0.tgz#c829491bcda643087259675361efba300d477615"
+  integrity sha512-oIRC3q5TA4zfNBv+UwNH10FKq1poAeRTrZUg5pmEcFNv2HpZfED30mb9fF0anNRbr7gmXrSY9iMsRSz6hkrmYQ==
+  dependencies:
+    csv-stringify "^5.6.2"
+    table "^6.7.1"
+
+"@as-covers/transform@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@as-covers/transform/-/transform-0.2.1.tgz#ea3cb56371493ba77b5761766d3ef46aba36d7c0"
+  integrity sha512-FutGj2yMIT2GOfqXrbnqSpeZ0eB5Bsnsg+BLnmqpEszthFhe/5/hKYmfNsiF2QBYZnqcIQ7dHw/z31+PlyUDug==
+  dependencies:
+    line-column "^1.0.2"
+    visitor-as "^0.6.0"
+
 "@as-pect/assembly@^6.0.0":
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/@as-pect/assembly/-/assembly-6.0.0.tgz#c8df070dadf1732d27cbefdf07d60a782a34a9ec"
   integrity sha512-B1bBMg2onl+RomWLlsWfrHdB8d4Xu7GOJn5eMwI4gjXvDKfbNXeSrL1gdkL7oZAHCf04XJ0XRWdUXfPdqTZdGA==
+
+"@as-pect/assembly@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@as-pect/assembly/-/assembly-6.2.0.tgz#29a0efa173df321354b76d92228e46944159ba95"
+  integrity sha512-jYr1jdlr0xNndIhOpTMBaPHmlhD/c3PcVCzow8wIkzLxgcSOzhBkqjip+LWPWGsiFK1vsZ8ZUaMTeK3fcnXQhw==
 
 "@as-pect/cli@^6.0.0":
   version "6.0.0"
@@ -20,6 +55,20 @@
     "@as-pect/csv-reporter" "^6.0.0"
     "@as-pect/json-reporter" "^6.0.0"
 
+"@as-pect/cli@^6.2.4":
+  version "6.2.4"
+  resolved "https://registry.yarnpkg.com/@as-pect/cli/-/cli-6.2.4.tgz#83476d235a6bfb9052e78cef24e450c199ae9146"
+  integrity sha512-OSWehx90djGxgR4RxFZKixRyh9hsMLNM/6otayAljijEPjiD1zS2lxu3WCu/DiwSWIRJUYdGOUVzw15nqvdcZQ==
+  dependencies:
+    "@as-covers/core" "0.2.1"
+    "@as-pect/assembly" "^6.2.0"
+    "@as-pect/core" "^6.2.1"
+    chalk "^4.1.1"
+    glob "^7.1.7"
+  optionalDependencies:
+    "@as-pect/csv-reporter" "^6.2.1"
+    "@as-pect/json-reporter" "^6.2.1"
+
 "@as-pect/core@^6.0.0":
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/@as-pect/core/-/core-6.0.0.tgz#e522a85738829c1d4872136b1b647b2c5b0ace7b"
@@ -30,12 +79,29 @@
     chalk "^4.1.0"
     long "^4.0.0"
 
+"@as-pect/core@^6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@as-pect/core/-/core-6.2.1.tgz#fa1f3658e337506c19df7944f75a8ba7b13aed97"
+  integrity sha512-JnvUb55OhGP7CYUnYtsLXttUb+FGv+6kEN9NleTbIMvU73NFJzyTCGjoZuayPNpfiUzOF96j91XuMHuinJ8BAg==
+  dependencies:
+    "@as-pect/assembly" "^6.2.0"
+    "@as-pect/snapshots" "^6.2.1"
+    chalk "^4.1.1"
+    long "^4.0.0"
+
 "@as-pect/csv-reporter@^6.0.0":
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/@as-pect/csv-reporter/-/csv-reporter-6.0.0.tgz#7c0eb306dfa59acececd36ecef5a333a914f4744"
   integrity sha512-2SrSN0UstjUlFCW7L/Z33tufTfWDOwPAZZ8WJNiiWbOgPSh0ML899DabR8UbH7eVQe1aeyS2LCSjhVKtmb7uSg==
   dependencies:
     "@as-pect/core" "^6.0.0"
+
+"@as-pect/csv-reporter@^6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@as-pect/csv-reporter/-/csv-reporter-6.2.1.tgz#fe7e23ac2d811e2519006ccc82f5245adcaad526"
+  integrity sha512-jy8ka8dEP4UY/pK/OIjHFUqs4j2Hvw3r6no6XfX1AkOd9CRLlt/JIDddlzwEqCGEfF83GSBQfQ1At86FkE7RtA==
+  dependencies:
+    "@as-pect/core" "^6.2.1"
 
 "@as-pect/json-reporter@^6.0.0":
   version "6.0.0"
@@ -44,10 +110,25 @@
   dependencies:
     "@as-pect/core" "^6.0.0"
 
+"@as-pect/json-reporter@^6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@as-pect/json-reporter/-/json-reporter-6.2.1.tgz#a77c3257aed8e5b1e5175509fb1046c1f94851cf"
+  integrity sha512-vsTYOiqB42+WPpec0M3apm9P2SjstUe6MfXepDvVIu2DCZzt1rkEuIIXro13LLQCnOzwXgHO/00sn+uPEjsmSQ==
+  dependencies:
+    "@as-pect/core" "^6.2.1"
+
 "@as-pect/snapshots@^6.0.0":
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/@as-pect/snapshots/-/snapshots-6.0.0.tgz#083b2b43571c8cbca3462dff1780de4e31a830d7"
   integrity sha512-5OMKJWYm3cfEX28TroY9j5CIhwO6q/300GShrxpDaNYva/HgA8iPY4dGdbiI4xcCf8xaHuBq2HQi0kYS+1wqjQ==
+  dependencies:
+    diff "^5.0.0"
+    nearley "^2.20.1"
+
+"@as-pect/snapshots@^6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@as-pect/snapshots/-/snapshots-6.2.1.tgz#237ed3b958e85b3e527a0e9f43292813b6dbf789"
+  integrity sha512-a6xcOUaXMrR3f1n6vgGxMJxUUd6MIVm5vlQ3nZ2hDEMz1PFyEQ04OvGqqUIYHhKAeXIvD3iwz02cI8Wh9lDK7Q==
   dependencies:
     diff "^5.0.0"
     nearley "^2.20.1"
@@ -1809,6 +1890,16 @@ ajv@^7.0.2:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
+ajv@^8.0.1:
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
+  integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
 ansi-colors@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
@@ -1852,6 +1943,11 @@ ansi-regex@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
+
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
 ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
@@ -2879,6 +2975,11 @@ cssstyle@^2.2.0:
   integrity sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
   dependencies:
     cssom "~0.3.6"
+
+csv-stringify@^5.6.2:
+  version "5.6.5"
+  resolved "https://registry.yarnpkg.com/csv-stringify/-/csv-stringify-5.6.5.tgz#c6d74badda4b49a79bf4e72f91cce1e33b94de00"
+  integrity sha512-PjiQ659aQ+fUTQqSrd1XEDnOr52jh30RBurfzkscaE2tPaFsDH5wOAHJiw8XAHphRknCwMUE9KRayc4K/NbO8A==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -3995,6 +4096,18 @@ glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^7.1.7:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
+  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.1.1"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 globals@^11.1.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
@@ -4654,7 +4767,7 @@ is-wsl@^2.2.0:
   dependencies:
     is-docker "^2.0.0"
 
-isarray@1.0.0, isarray@~1.0.0:
+isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
@@ -5302,6 +5415,14 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+line-column@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/line-column/-/line-column-1.0.2.tgz#d25af2936b6f4849172b312e4792d1d987bc34a2"
+  integrity sha512-Ktrjk5noGYlHsVnYWh62FLVs4hTb8A3e+vucNZMgPeAOITdshMSgv4cCZQeRDjm7+goqmo6+liZwTXo+U3sVww==
+  dependencies:
+    isarray "^1.0.0"
+    isobject "^2.0.0"
+
 lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
@@ -5449,6 +5570,11 @@ lodash.templatesettings@^4.0.0:
   integrity sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==
   dependencies:
     lodash._reinterpolate "^3.0.0"
+
+lodash.truncate@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
+  integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
 
 lodash.uniq@^4.5.0:
   version "4.5.0"
@@ -5719,6 +5845,13 @@ minimatch@^3.0.0, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
+  dependencies:
+    brace-expansion "^1.1.7"
+
+minimatch@^3.1.1:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
 
@@ -7576,6 +7709,15 @@ string-width@^4.1.0, string-width@^4.2.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
 
+string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
 string.prototype.trimend@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz#a22bd53cca5c7cf44d7c9d5c732118873d6cd18b"
@@ -7642,6 +7784,13 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
+
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-bom@^2.0.0:
   version "2.0.0"
@@ -7739,6 +7888,17 @@ table@^6.0.4:
     lodash "^4.17.20"
     slice-ansi "^4.0.0"
     string-width "^4.2.0"
+
+table@^6.7.1:
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/table/-/table-6.8.0.tgz#87e28f14fa4321c3377ba286f07b79b281a3b3ca"
+  integrity sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==
+  dependencies:
+    ajv "^8.0.1"
+    lodash.truncate "^4.4.2"
+    slice-ansi "^4.0.0"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
 
 tar@^4.4.10, tar@^4.4.12, tar@^4.4.8:
   version "4.4.13"
@@ -7977,6 +8137,11 @@ ts-mixer@^5.1.0:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/ts-mixer/-/ts-mixer-5.4.0.tgz#f98583e6acd72bf4c7a04481352ebfd203171297"
   integrity sha512-Z5u/hpTkP4VWTIQT5vzxyeFAe8siPkatOC0Q49Uf56ccMGSHosI/IEo+t8BFvJX9yiF111YEOKfKY3m72V7F/w==
+
+ts-mixer@^5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/ts-mixer/-/ts-mixer-5.4.1.tgz#b90db9ced48531aa17ce9184a2890d1e3c99b1e5"
+  integrity sha512-Zo9HgPCtNouDgJ+LGtrzVOjSg8+7WGQktIKLwAfaNrlOK1mWGlz1ejsAF/YqUEqAGjUTeB5fEg8gH9Aui6w9xA==
 
 ts-node@^9.0.0:
   version "9.1.1"
@@ -8273,6 +8438,14 @@ visitor-as@^0.5.0:
   dependencies:
     lodash.clonedeep "^4.5.0"
     ts-mixer "^5.1.0"
+
+visitor-as@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/visitor-as/-/visitor-as-0.6.0.tgz#b0cca3c918bd9d396545faf08529d2b9ba968a40"
+  integrity sha512-4WcnwCLXWjhNkwJj9gSqh46sdIv9CyIvnSuwr61OOfrGCtN2mKcW5KE828OeEr1rYjEy0Z/CIdPBJKJRLsUgDA==
+  dependencies:
+    lodash.clonedeep "^4.5.0"
+    ts-mixer "^5.4.1"
 
 vscode-textmate@^5.2.0:
   version "5.2.0"


### PR DESCRIPTION
I'm not able to run the unit test without having `@as-pect/cli` as a dependency in `near-sdk-as`.